### PR TITLE
Fix Volume Mount for Postgres 18+

### DIFF
--- a/files/docker-compose.yml
+++ b/files/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       POSTGRES_USER: ghosts
       POSTGRES_PASSWORD: scotty@1
     volumes:
-      - ./_db:/var/lib/postgresql/data
+      - ./_db:/var/lib/postgresql
     logging:
       options:
         max-size: '100m'


### PR DESCRIPTION
Update docker-compose.yml to ensure Postgres starts up correctly.

Previous mount of `/var/lib/postgresql/data` was causing startup issues. New mount needs to be `/var/lib/postgresql`.

Fixes #5 